### PR TITLE
feat: add preview download option to search API

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ Usage:
 - Choose “Search Apple Music”, enter a query, then click “Play” on a result.
 - The app calls the remote server’s `/api/download` which runs `gamdl` under the hood, returns audio+lyrics, and jumps straight to the READY screen.
 
+For direct API use:
+
+- `GET /api/search?term=hello&downloadPreview=1` – search Apple Music. When `downloadPreview=1`, each result includes a `previewDataUrl` field with base64-encoded preview audio.
+- `POST /api/download` – JSON body `{ "url": "https://music.apple.com/..." }` returns full track audio and synced lyrics.
+
 Notes:
 - The API is separate from the GitHub Pages frontend; host it wherever you like.
 - The server sends audio as a data URL and LRC as text; nothing is persisted.


### PR DESCRIPTION
## Summary
- allow `/api/search` to optionally return base64-encoded preview audio via `downloadPreview=1`
- document API usage for direct access

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c5b83a4690832ca08f522dbb4bed40

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GET /api/search with optional downloadPreview to include base64 preview audio in results.
  * Added POST /api/download to return full track audio and synced lyrics for a given Apple Music URL.
  * Search results gracefully omit preview audio when unavailable without failing the request.

* **Documentation**
  * Added “For direct API use” guide under Usage.
  * Clarified API can be hosted independently of the GitHub Pages frontend.
  * Explained responses: audio served as data URLs, lyrics as LRC text, with no persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->