### PR TITLE
ci: deploy PR previews to GitHub Pages

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,58 @@
+name: Deploy PR Preview to GitHub Pages
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages-preview-${{ github.event.pull_request.number }}"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '18'
+        cache: 'npm'
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Build project
+      run: npm run build
+
+    - name: Setup Pages
+      uses: actions/configure-pages@v4
+
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: './dist'
+
+  deploy:
+    if: github.event.pull_request.draft == false
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+    - name: Deploy PR preview
+      id: deployment
+      uses: actions/deploy-pages@v4
+      with:
+        preview: true


### PR DESCRIPTION
## Summary
- add a pull request workflow that builds the site and publishes a preview to GitHub Pages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca262ee914832c9ed734a653a4bea3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Introduced automated PR preview deployments to GitHub Pages for non-draft pull requests. Each update builds the app and publishes an ephemeral preview with a shareable link, enabling quicker visual reviews and QA before merge.
  - Stale preview runs are automatically canceled to save time and resources.
  - Previews are isolated from production and scoped to the PR’s lifecycle, improving collaboration without impacting live environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->